### PR TITLE
Add npm package data to use in web projects more easily

### DIFF
--- a/web font/index.css
+++ b/web font/index.css
@@ -1,0 +1,1 @@
+@import url("./complete/font.css")

--- a/web font/package.json
+++ b/web font/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "manrope",
+  "version": "2.0.0",
+  "description": "Manrope font - modern geometric sans-serif",
+  "main": "index.css",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sharanda/manrope.git"
+  },
+  "keywords": [
+    "typeface",
+    "font",
+    "font",
+    "family",
+    "manrope"
+  ],
+  "author": "sharanda",
+  "license": "OFL-1.1",
+  "bugs": {
+    "url": "https://github.com/sharanda/manrope/issues"
+  },
+  "homepage": "https://github.com/sharanda/manrope#readme"
+}


### PR DESCRIPTION
This PR adds a package.json file in the `web font` directory. It allows users of webpack to be able to run `require('manrope')` to easily add the font to their projects. I have already published this, but wouldn't mind adding someone else from this project as the package owner if they request. Feel free to reach out via email (my username @gmail.com)